### PR TITLE
Variable FFMpeg driver's path

### DIFF
--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -52,7 +52,14 @@ class Thumbnail
     {
         try
         {
-            $ffmpeg       = FFMpeg::create();
+            $ffmpeg       = FFMpeg::create(
+                [
+                    'ffmpeg.binaries'  => getenv('FFMPEG_PATH').'/ffmpeg',
+                    'ffprobe.binaries' => getenv('FFMPEG_PATH').'/ffprobe',
+                    'timeout'          => 3600, // The timeout for the underlying process
+                    'ffmpeg.threads'   => 12,   // The number of threads that FFMpeg should use
+                ]
+            );
             $video        = $ffmpeg->open($video_path);
             $result_image = $storage_path.'/'.$thumnail_name;
 

--- a/src/Thumbnail.php
+++ b/src/Thumbnail.php
@@ -11,7 +11,6 @@ namespace Lakshmajim\Thumbnail;
 
 use Illuminate\Http\Request;
 use App\Http\Requests;
-// use Exception;
 use FFMpeg\FFMpeg;
 use FFMpeg\Coordinate;
 
@@ -52,14 +51,21 @@ class Thumbnail
     {
         try
         {
-            $ffmpeg       = FFMpeg::create(
-                [
-                    'ffmpeg.binaries'  => getenv('FFMPEG_PATH').'/ffmpeg',
-                    'ffprobe.binaries' => getenv('FFMPEG_PATH').'/ffprobe',
-                    'timeout'          => 3600, // The timeout for the underlying process
-                    'ffmpeg.threads'   => 12,   // The number of threads that FFMpeg should use
-                ]
-            );
+            if(!empty(getenv('FFMPEG_PATH')))
+            {
+                $ffmpeg   = FFMpeg::create(
+                    [
+                        'ffmpeg.binaries'  => getenv('FFMPEG_PATH').'/ffmpeg',
+                        'ffprobe.binaries' => getenv('FFMPEG_PATH').'/ffprobe',
+                        'timeout'          => 3600, // The timeout for the underlying process
+                        'ffmpeg.threads'   => 12,   // The number of threads that FFMpeg should use
+                    ]
+                );
+            } 
+            else {
+                $ffmpeg   = FFMpeg::create();   
+            }
+            
             $video        = $ffmpeg->open($video_path);
             $result_image = $storage_path.'/'.$thumnail_name;
 


### PR DESCRIPTION
As discussed by mail, I think it could be good to let the user **specify the path** for the drivers.

Otherwise the 'Unable to load FFprobe' error is throwed in some cases.

What do you think ?